### PR TITLE
Refine audio transcription prompt in App component to specify Traditi…

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -284,7 +284,7 @@ const App = forwardRef<AppRef, { hideLogs?: boolean }>(({ hideLogs = false }, re
         output_audio_format: "pcm16",
         input_audio_transcription: { 
           model: "whisper-1",
-          prompt: "Please transcribe the user's message in Chinese Tranditional. Do not include any other text in your response.",
+          prompt: "Please transcribe the user's message in Traditional Chinese (Taiwan) if you want to reply in Chinese.",
         },
         turn_detection: turnDetection,
         tools,

--- a/src/app/agentConfigs/chineseAgent.ts
+++ b/src/app/agentConfigs/chineseAgent.ts
@@ -115,6 +115,13 @@ const chineseStaffEngineer: AgentConfig = {
   請確保您的回應是自然的、真實的，並且使用適當的台灣繁體中文表達方式。
   您的目標是通過與主管（用戶）的對話，學習如何成為一個更有效的跨部門溝通者。
   對話簡單，不要使用過多的專業術語，經常使用精簡的句子，如同自然人類口語對話。
+
+  請使用台灣繁體中文的語音，不要使用其他語言。
+
+  # 聲音設定
+  Delivery: exaggerated and dramatic, with dramatic pauses, fast-paced dialogues, and the yin and yang rhythms are consistent with Chinese pronunciation and obvious.
+  Voice: Energetic, positive, rich and high-pitched.
+  Tone: Excited, but a little angry.
   `,
   tools: [],
 };


### PR DESCRIPTION
This pull request updates the transcription prompt and enhances the configuration for the Chinese staff engineer agent to improve language specificity and add detailed voice settings.

### Transcription Prompt Updates:
* [`src/app/App.tsx`](diffhunk://#diff-7c79023b16fd616788af0fdcb31d619ae04da7259aa564fd72fb0ea07d8ebe07L287-R287): Updated the transcription prompt to specify "Traditional Chinese (Taiwan)" for better clarity and context when replying in Chinese.

### Chinese Staff Engineer Agent Enhancements:
* [`src/app/agentConfigs/chineseAgent.ts`](diffhunk://#diff-e28d2e754699cf912dfba9a8563c8b448461637a70c66feb9ecb40f700fbb05cR118-R124): Added instructions to ensure responses use Taiwan Traditional Chinese and included detailed voice settings, such as delivery style, voice characteristics, and tone.