### PR TITLE
Fix history

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -295,7 +295,25 @@ const App = forwardRef<AppRef, { hideLogs?: boolean }>(({ hideLogs = false }, re
     sendClientEvent(sessionUpdateEvent);
 
     if (shouldTriggerResponse) {
-      sendSimulatedUserMessage("你好");
+      // Format transcriptItems into readable chat history
+      const chatHistory = transcriptItems
+        .filter(item => item && item.type === 'MESSAGE' && item.role && item.title)
+        .map(item => `${item.role}: ${item.title}`)
+        .join('\n\n');
+
+      sendClientEvent(
+        {
+          type: "conversation.item.create",
+          item: {
+            type: "message",
+            role: "system",
+            content: [{ type: "input_text", text: `之前的對話紀錄:\n${chatHistory}` }],
+          },
+        },
+        "(simulated history message)"
+      );
+      console.log(`之前的對話紀錄:\n${chatHistory}`);
+      sendSimulatedUserMessage("接著繼續");
     }
   };
 

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -283,8 +283,9 @@ const App = forwardRef<AppRef, { hideLogs?: boolean }>(({ hideLogs = false }, re
         input_audio_format: "pcm16",
         output_audio_format: "pcm16",
         input_audio_transcription: { 
-          model: "whisper-1",
+          model: "gpt-4o-transcribe",
           language: "zh",
+          prompt: "以下是來自於台灣人的對話"
         },
         turn_detection: turnDetection,
         tools,

--- a/src/app/contexts/TranscriptContext.tsx
+++ b/src/app/contexts/TranscriptContext.tsx
@@ -11,6 +11,7 @@ type TranscriptContextValue = {
   addTranscriptBreadcrumb: (title: string, data?: Record<string, any>) => void;
   toggleTranscriptItemExpand: (itemId: string) => void;
   updateTranscriptItemStatus: (itemId: string, newStatus: "IN_PROGRESS" | "DONE") => void;
+  clearTranscript: () => void;
 };
 
 const TranscriptContext = createContext<TranscriptContextValue | undefined>(undefined);
@@ -97,6 +98,10 @@ export const TranscriptProvider: FC<PropsWithChildren> = ({ children }) => {
     );
   };
 
+  const clearTranscript: TranscriptContextValue["clearTranscript"] = () => {
+    setTranscriptItems([]);
+  };
+
   return (
     <TranscriptContext.Provider
       value={{
@@ -106,6 +111,7 @@ export const TranscriptProvider: FC<PropsWithChildren> = ({ children }) => {
         addTranscriptBreadcrumb,
         toggleTranscriptItemExpand,
         updateTranscriptItemStatus,
+        clearTranscript,
       }}
     >
       {children}

--- a/src/app/demo/dynamic-analysis/page.tsx
+++ b/src/app/demo/dynamic-analysis/page.tsx
@@ -39,7 +39,7 @@ function DynamicAnalysisContent() {
   }, []);
 
   const handleTalkOn = async () => {
-    alert("handleTalkOn");
+    // alert("handleTalkOn");
     setIsPTTUserSpeaking(true);
 
     if (appRef.current) {
@@ -75,7 +75,7 @@ function DynamicAnalysisContent() {
   };
 
   const handleTalkOff = async () => {
-    alert("handleTalkOff");
+    // alert("handleTalkOff");
     setIsPTTUserSpeaking(false);
 
 

--- a/src/app/demo/dynamic-analysis/page.tsx
+++ b/src/app/demo/dynamic-analysis/page.tsx
@@ -276,8 +276,9 @@ function DynamicAnalysisContent() {
       // 這邊忽略 lastUserInputIndex === 2 的訊息，不讓它出現在畫面上
       if (lastUserInputIndex !== -1 && lastUserInputIndex !== lastInput.current.lastUserInputIndex) {
         if (lastUserInputIndex === 2) { return; }
-        // 忽略內容為"接著繼續"的消息
-        if (transcriptItems[lastUserInputIndex].title === "接著繼續") { return; }
+        // 忽略特定內容的消息
+        const messageContent = transcriptItems[lastUserInputIndex].title;
+        if (messageContent === "接著繼續" || messageContent === "以下是來自於台灣人的對話") { return; }
         onNewMessage(lastUserInputIndex);
         lastInput.current = {
           ...lastInput.current,
@@ -286,8 +287,9 @@ function DynamicAnalysisContent() {
       }
       if (lastUserInputIndex >= 0) {
         if (lastUserInputIndex === 2) { return; }
-        // 忽略內容為"接著繼續"的消息
-        if (transcriptItems[lastUserInputIndex].title === "接著繼續") { return; }
+        // 忽略特定內容的消息
+        const messageContent = transcriptItems[lastUserInputIndex].title;
+        if (messageContent === "接著繼續" || messageContent === "以下是來自於台灣人的對話") { return; }
         const item = transcriptItems[lastUserInputIndex]
         chatContext.updateMessageContent(item.itemId, item.title!);
       }

--- a/src/app/demo/dynamic-analysis/page.tsx
+++ b/src/app/demo/dynamic-analysis/page.tsx
@@ -88,6 +88,15 @@ function DynamicAnalysisContent() {
       // Send cancel event to ensure assistant stops speaking
       sendClientEvent({ type: "response.cancel" }, "cancel assistant speech");
     }
+
+    const end_id = uuidv4().slice(0, 32);
+    chatContext.addMessageItem({
+      id: end_id,
+      type: 'text',
+      role: 'user',
+      data: { content: "通話已結束" },
+      createdAtMs: Date.now(),
+    });
   };
 
   const handleMicrophoneClick = () => {


### PR DESCRIPTION
This pull request introduces several enhancements and fixes to the transcript management and dynamic analysis features in the application. Key changes include switching the transcription model, adding a new method to clear transcripts, improving conversation handling, and refining message filtering logic.

### Transcript Management Enhancements:
* Added a `clearTranscript` method to the `TranscriptContext` for resetting the transcript items. This method was integrated into the `TranscriptProvider` and used on page refresh in `DynamicAnalysisContent`. [[1]](diffhunk://#diff-41ac2fbd1c7fbf1869cbb7608c1f0dcf2a18e3c78a6c2c246d820532983de635R14) [[2]](diffhunk://#diff-41ac2fbd1c7fbf1869cbb7608c1f0dcf2a18e3c78a6c2c246d820532983de635R101-R104) [[3]](diffhunk://#diff-41ac2fbd1c7fbf1869cbb7608c1f0dcf2a18e3c78a6c2c246d820532983de635R114) [[4]](diffhunk://#diff-a3e56d0deed85fc3e3ec44096fe1541635b425922024582dcfa262c3a1307552L18-R18) [[5]](diffhunk://#diff-a3e56d0deed85fc3e3ec44096fe1541635b425922024582dcfa262c3a1307552R34-R114)

### Conversation Handling Improvements:
* Replaced the transcription model from `"whisper-1"` to `"gpt-4o-transcribe"` and added a prompt for context in the transcription.
* Enhanced the conversation initialization by formatting `transcriptItems` into a readable chat history and sending it as a system message.
* Implemented logic to handle "push-to-talk" (PTT) interactions, including starting/stopping sessions, clearing audio buffers, and canceling ongoing assistant speech.

### Message Filtering Logic:
* Added filters to ignore specific user messages (e.g., "接著繼續" and "以下是來自於台灣人的對話") and assistant messages with content length less than 1. [[1]](diffhunk://#diff-a3e56d0deed85fc3e3ec44096fe1541635b425922024582dcfa262c3a1307552L261-R290) [[2]](diffhunk://#diff-a3e56d0deed85fc3e3ec44096fe1541635b425922024582dcfa262c3a1307552R299-R319)

### Code Cleanup:
* Removed unused example message initialization logic from `DynamicAnalysisContent`.